### PR TITLE
Jank fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ To run locally, `yarn`, then `yarn dev`, then open https://localhost:8000.
 - [Gatsby blog starter](https://github.com/gatsbyjs/gatsby-starter-blog).
 
 ## Todos
-- [x] Update all blog posts
-- [x] Live search
-- [x] Dark mode toggle
-- [x] Look into improving FOUC with Typekit (resolved for now with a fade-in entrance effect)
-- [x] 404 template
-- [ ] Something I added recently added some minor jank when navigating between pages. Let's fix this shall we?
+- [x] ~~Update all blog posts~~
+- [x] ~~Live search~~
+- [x] ~~Dark mode toggle~~
+- [x] ~~Look into improving FOUC with Typekit (resolved for now with a fade-in entrance effect)~~
+- [x] ~~404 template~~
+- [x] ~~Something I added recently added some minor jank when navigating between pages. Let's fix this shall we?~~
 - [ ] Tag support
 - [ ] Book reviews
 - [ ] Share buttons

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import { ThemeProvider } from './src/providers/ThemeProvider';
 import 'what-input';
+import { ThemeProvider, FontProvider } from '@providers';
 import '@lib/theme.css';
 
-export const wrapRootElement = ({ element }) => (
-  <ThemeProvider>{element}</ThemeProvider>
-);
+export const wrapRootElement = ({ element }) => {
+  return (
+    <ThemeProvider>
+      <FontProvider>{element}</FontProvider>
+    </ThemeProvider>
+  );
+};

--- a/src/components/BlogHeader/BlogHeader.css
+++ b/src/components/BlogHeader/BlogHeader.css
@@ -25,7 +25,7 @@
     position: relative;
     width: 100%;
     height: 0;
-    padding-top: 62.25%;
+    padding-top: 66.25%;
     overflow: hidden;
     box-shadow: 0 10px 40px -20px rgba(0, 0, 0, 0.325);
 
@@ -35,6 +35,7 @@
   }
 
   &__imageFigure {
+    position: absolute;
     top: 0;
     left: 0;
     width: 100%;
@@ -60,8 +61,12 @@
 
   &__image {
     display: block;
+    position: absolute;
+    top: 50%;
+    left: 50%;
     width: 100%;
     height: 100%;
+    transform: translate(-50%, -50%);
     object-fit: cover;
     object-position: 50%;
   }

--- a/src/components/BlogHeader/BlogHeader.js
+++ b/src/components/BlogHeader/BlogHeader.js
@@ -16,7 +16,7 @@ const BlogHeader = ({
 }) => {
   const [show, set] = useState(false);
   const transitions = useTransition(show, null, {
-    from: { position: 'absolute', opacity: 0 },
+    from: { opacity: 0 },
     enter: { opacity: 1 },
     leave: { opacity: 0 },
   });

--- a/src/components/DarkModeToggle/DarkModeToggle.js
+++ b/src/components/DarkModeToggle/DarkModeToggle.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { uniqueId } from 'lodash';
 import cx from 'classnames';
 import Toggle from '@components/Toggle';
-import { ThemeContext } from '@providers/ThemeProvider';
+import { ThemeContext } from '@providers';
 import './DarkModeToggle.css';
 
 export const DarkModeToggle = ({ tabIndex, className }) => {

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -3,7 +3,7 @@ import Helmet from 'react-helmet';
 import { uniq } from 'lodash';
 import cx from 'classnames';
 import { StaticQuery, graphql } from 'gatsby';
-import { ThemeContext } from '@providers/ThemeProvider';
+import { ThemeContext, FontContext } from '@providers';
 import HomeHeader from '@components/HomeHeader';
 import Burger from '@components/Burger'; /*  */
 import BlogHeader from '@components/BlogHeader';
@@ -12,8 +12,7 @@ import GithubButton from '@components/GithubButton';
 import SidePanel from '@components/SidePanel';
 import DarkModeToggle from '@components/DarkModeToggle';
 // import Menu from '@components/Menu';
-import { Fonts, webFonts } from '@lib/fonts';
-import { usePromise } from '@lib/hooks';
+import { webFonts } from '@lib/fonts';
 import './Layout.css';
 
 /* const MENU_ITEMS = [
@@ -41,9 +40,9 @@ const Layout = ({
   children,
   handleSearchChange,
 }) => {
-  const [fontsLoaded, fontError] = usePromise(Fonts(), []);
   const [menuIsActive, setMenuActiveState] = useState(false);
   const { darkMode } = useContext(ThemeContext);
+  const { fontsLoaded, fontError } = useContext(FontContext);
   const rootPath = `${__PATH_PREFIX__}/`; // eslint-disable-line
   const toggleMenu = () => setMenuActiveState(!menuIsActive);
   const renderFontLinks = () =>

--- a/src/providers/FontProvider.js
+++ b/src/providers/FontProvider.js
@@ -1,0 +1,19 @@
+import React, { createContext } from 'react';
+import { usePromise } from '@lib/hooks';
+import { Fonts } from '@lib/fonts';
+
+const defaultState = { fontsLoaded: true, fontError: null };
+
+export const FontContext = createContext(defaultState);
+
+export const FontProvider = ({ children }) => {
+  const isBrowser = typeof window === 'object';
+  const [fontsLoaded, fontError] = usePromise(Fonts(), []);
+  return (
+    <FontContext.Provider
+      value={{ fontsLoaded: isBrowser ? fontsLoaded : true, fontError }}
+    >
+      {children}
+    </FontContext.Provider>
+  );
+};

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -1,0 +1,4 @@
+import { FontProvider, FontContext } from './FontProvider';
+import { ThemeProvider, ThemeContext } from './ThemeProvider';
+
+export { FontContext, FontProvider, ThemeContext, ThemeProvider };


### PR DESCRIPTION
- The `fontsLoaded` conditionally applies a classname in the Layout component, which was re-rendered on every route change. The value was updated briefly on each render, causing a flicker in the CSS transition.
- Moved the function to load fonts into a provider that is applied above the Layout tree for all pages so that the value persists across route changes